### PR TITLE
Translate conditional call+assignments to ifs

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -339,6 +339,15 @@ var yo = typeof a !== "undefined" && a !== null ? \
 }`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('converts call in existential chain to if', () => {
+    const example = 'document.getElementById("id")?.scrollTop = 0;';
+    const expected =
+`if (document.getElementById("id") != null) {
+  document.getElementById("id").scrollTop = 0;
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('Boolean Expression', () => {


### PR DESCRIPTION
Converts conditional call+assignments to ifs (previously, decaf would throw `undefined does not match field "name": string of type Identifier`).

/cc @lemonmade 
