### PR TITLE
`[this.foo] = ['bar']` should not not generate a var declaration

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1333,6 +1333,33 @@ var {
 ref = this.options, this.a = ref.a, this.b = ref.b, ref;`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('does not declare this members', () => {
+    const example = `[@foo, bar] = ['foo', foobar];`;
+    const expected =
+`var bar;
+[this.foo, bar] = ["foo", foobar];`;
+
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('does not generate var declaration when assigning only to members', () => {
+    const example = `[@foo, @bar] = ['foo', foobar];`;
+    const expected =
+`[this.foo, this.bar] = ["foo", foobar];`;
+
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('declares non-member vars outside of conditional assignments', () => {
+    const example = `[@currentField, direction, foo] = params.order.split(' ') if params.order`;
+    const expected =
+`var direction;
+var foo;
+(params.order ? [this.currentField, direction, foo] = params.order.split(" ") : undefined);`;
+
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('conditional statements', () => {


### PR DESCRIPTION
decaf generates a `var` declaration for anything in a `[foo] = ['bar']` assignment.  Unfortunately, this turns:

`var [@bar] = ['foo']` 

into this (invalid) JavaScript 

`var [this.foo] = ['foo']`.

To work around this, I've added a check for any `this` references in an array assignment.  If `this` is found, any non-member references are declared separately.

I've run through through our codebase and it fixes everything listed in Shopify/esify#7.

@lemonmade, please take a look
