### PR TITLE
Fix bound methods

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -345,28 +345,36 @@ function mapClassBody(node, meta) {
     }
 
     // bind all the bound methods to the class
-    constructor.value.body.body =
-      constructor.value.body.body.concat(
-        boundMethods.map(identifier =>
-          b.expressionStatement(
-            b.assignmentExpression('=',
+    const body = constructor.value.body.body;
+    const hasSuper = !!findWhere(body, {
+      expression: {
+        callee: {
+          name: 'super',
+        },
+      },
+    });
+
+    body.splice(hasSuper ? 1 : body.length, 0,
+      ...boundMethods.map(identifier =>
+        b.expressionStatement(
+          b.assignmentExpression('=',
+            b.memberExpression(
+              b.thisExpression(),
+              identifier
+            ),
+            b.callExpression(
               b.memberExpression(
-                b.thisExpression(),
-                identifier
-              ),
-              b.callExpression(
                 b.memberExpression(
-                  b.memberExpression(
-                    b.thisExpression(),
-                    identifier
-                  ),
-                  b.identifier('bind')
+                  b.thisExpression(),
+                  identifier
                 ),
-                [b.thisExpression()]
-              )
+                b.identifier('bind')
+              ),
+              [b.thisExpression()]
             )
           )
         )
+      )
     );
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -989,6 +989,30 @@ class unnamedClass1 extends Parent {
     expect(compile(example)).toEqual(expected);
   });
 
+  it('binds fat arrow methods before the constructor body', () => {
+    const example =
+`class A
+  constructor: ->
+    super
+    document.addEventListener("event", this.b)
+
+  b: => bom + 123
+`;
+    const expected =
+`class A {
+  constructor() {
+    super(...arguments);
+    this.b = this.b.bind(this);
+    document.addEventListener("event", this.b);
+  }
+
+  b() {
+    return bom + 123;
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
   it('extends a class with the extend keyword', () => {
     const example =
 `class A extends B


### PR DESCRIPTION
This PR does a quick fix to make sure that binding methods works correctly when they are used in the constructor. It basically just moves the binding declarations up from the bottom of the constructor to the first spot after `super` (or at the top if no `super`).

cc/ @GoodForOneFare 
