### PR TITLE
Fix complex `for when` translation

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1159,18 +1159,25 @@ function mapSwitchStatement(node, meta) {
   );
 }
 
+function mapForGuard(guardNode, blockStatement, meta) {
+  const isExistential = guardNode.constructor.name === 'Existence';
+  const guardClause = isExistential ?
+    mapExistentialExpression(guardNode, meta) :
+    mapOp(guardNode.expression || guardNode, meta);
+
+  return b.blockStatement([
+    b.ifStatement(
+      guardClause,
+      blockStatement
+    ),
+  ]);
+}
+
 function mapForStatement(node, meta) {
   let blockStatement = mapBlockStatement(node.body, meta);
 
   if (node.guard) {
-    const guardBase = node.guard.expression || node.guard;
-
-    blockStatement = b.blockStatement([
-      b.ifStatement(
-        mapOp(guardBase, meta),
-        blockStatement
-      ),
-    ]);
+    blockStatement = mapForGuard(node.guard, blockStatement, meta);
   }
 
   if (node.object === false) {

--- a/test/test.js
+++ b/test/test.js
@@ -2594,6 +2594,7 @@ modulo1(1, 5);`;
 });
 
 describe('for loops with conditional', () => {
+
   it('handles truthy property', () => {
     const example =
 `
@@ -2615,7 +2616,7 @@ for value in values when foo
 
     const expected =
 `for (let value of values) {
-  if (value) {
+  if (typeof value !== "undefined" && value !== null) {
     loopAction(value);
   }
 }`;


### PR DESCRIPTION
- `mapForStatement` notices if a loop comprehension (guard) exists, and wraps the loop logic in an `if` block.
- `mapOp` now handles edge cases introduced by Shopify's very "rich" loop guards.

/cc @lemonmade, @fandy
