### PR TITLE
Merge in mainline decaf fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "license": "ISC",
   "dependencies": {
     "ast-types": "0.8.13",
-    "chalk": "^1.1.1",
+    "chalk": "1.1.1",
     "coffee-script": "1.10.0",
-    "commander": "^2.9.0",
-    "jscodeshift": "0.3.12",
+    "commander": "2.9.0",
+    "jscodeshift": "0.3.20",
     "lodash": "3.10.1",
-    "node-dir": "^0.1.11",
-    "recast": "benjamn/recast#b0f031b1a36199308a1eb77cc9709d554f14e671"
+    "node-dir": "0.1.11",
+    "recast": "0.11.5"
   },
   "devDependencies": {
     "babel": "6.1.18",

--- a/src/parser.js
+++ b/src/parser.js
@@ -1097,9 +1097,12 @@ function insertArrayAssignmentVarDeclarations(assignmentPath) {
 
 function getAssignmentIdentifiers(path) {
   const elements = path.value && path.value.left && path.value.left.elements;
-  return elements ?
-    elements.filter(element => element.type !== jsc.MemberExpression.name) :
-    null;
+  if (!elements) {
+    return null;
+  }
+
+  const inScopeIds = elements.filter(element => element.type !== jsc.MemberExpression.name);
+  return new Set(inScopeIds);
 }
 
 function findNodeParent(node, matcher) {
@@ -1157,9 +1160,10 @@ function insertVariableDeclarations(ast) {
         path.scope.scan(true);
       } else {
         const identifiers = getAssignmentIdentifiers(path) || [path.value.left];
-        identifiers.reverse().forEach(id =>
+        identifiers.forEach(id =>
           path.scope.injectTemporary(id)
         );
+        path.scope.scan(true);
       }
     }
   });

--- a/src/parser.js
+++ b/src/parser.js
@@ -1083,15 +1083,12 @@ function insertArrayAssignmentVarDeclarations(assignmentPath) {
     .find(jsc.Identifier)
     .filter(path => path.parentPath.name === 'elements')
     .paths()
-    .map(path => jsc.identifier(path.value.name))
-    .map(identifier => jsc.variableDeclarator(identifier, null));
+    .map(path => path.value.name);
 
   if (identifiers.length > 0) {
-    jsc(assignmentPath)
-      .closest(jsc.Statement)
-      .insertBefore([
-        jsc.variableDeclaration('var', identifiers),
-      ]);
+    identifiers.forEach(id =>
+      assignmentPath.scope.injectTemporary(jsc.identifier(id), null)
+    );
   }
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,8 +18,6 @@ const IS_NUMBER = /^[+-]?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)$/i;
 const IS_STRING = /^['"]/;
 const IS_REGEX = /^\//;
 
-const STRING_INSIDE_QUOTES = /^['"](.*)['"]$/;
-
 function mapBoolean(node) {
   if (node.base.val === 'true') {
     return b.literal(true);
@@ -66,7 +64,7 @@ function mapLiteral(node) {
   if (value === 'NaN') {
     return b.literal(NaN);
   } else if (IS_STRING.test(value)) {
-    return b.literal(value.match(STRING_INSIDE_QUOTES)[1]);
+    return b.literal(eval(value)); // eslint-disable-line no-eval
   } else if (IS_NUMBER.test(value)) {
     return b.literal(Number(value));
   } else if (IS_REGEX.test(value)) {

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,10 @@ function compile(source) {
 describe('Values', () => {
   it('strings', () => {
     expect(compile('"yoyoyo"')).toEqual('"yoyoyo";');
+    expect(compile(`"#{_.escape(text).replace(/\\n/g, '<br>')}<br>"`)).toEqual(`(_.escape(text).replace(/\\n/g, "<br>")) + "<br>";`);
+    expect(compile(`'\\''`)).toEqual(`"'";`);
+    expect(compile(`"\\""`)).toEqual(`"\\"";`);
+    expect(compile(`"\\\\\\\\"`)).toEqual(`"\\\\";`);
   });
 
   it('numbers', () => {
@@ -63,6 +67,18 @@ describe('multiline strings', () => {
 "
 """`;
     const expected = String.raw`"\"";`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('should escape more complex strings properly', () => {
+    const example =
+`"""
+<div id="outer" style="height: #{CONTAINER_HEIGHT}px; overflow: scroll">
+  <div id="inner" style="height: #{CONTENT_HEIGHT}px"></div>
+</div>
+"""`;
+
+    const expected = `"<div id=\\"outer\\" style=\\"height: " + (CONTAINER_HEIGHT) + "px; overflow: scroll\\">\\n  <div id=\\"inner\\" style=\\"height: " + (CONTENT_HEIGHT) + "px\\"></div>\\n</div>";`; // eslint-disable-line max-len
     expect(compile(example)).toEqual(expected);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1440,9 +1440,12 @@ ref = this.options, this.a = ref.a, this.b = ref.b, ref;`;
   it('declares non-member vars outside of conditional assignments', () => {
     const example = `[@currentField, direction, foo] = params.order.split(' ') if params.order`;
     const expected =
-`var direction;
-var foo;
-(params.order ? [this.currentField, direction, foo] = params.order.split(" ") : undefined);`;
+`var foo;
+var direction;
+
+if (params.order) {
+  [this.currentField, direction, foo] = params.order.split(" ");
+}`;
 
     expect(compile(example)).toEqual(expected);
   });


### PR DESCRIPTION
Merges in recent fixes from `juliankrispel/decaf`.  This should get us closer to submitting stuff back to mainline, and not maintaining our own fork.

Also includes 3 tweaks:
- For inline assignments, generate ternary assignments (mainline now prefers IIFEs)
- Tweak to `shopify/decaf` logic to prevent duplicate local var declarations
- Tweak to `shopify/decaf` logic to declare bulk-destructuring-assignment vars at the "top" of scope

/cc @lemonmade, @fandy
