### PR TITLE
Move private class calls to after the class definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-decaf",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "A coffeescript to es6 transpiler",
   "repository": {
     "type": "git",

--- a/src/parser.js
+++ b/src/parser.js
@@ -1592,10 +1592,11 @@ function mapExistentialAssignmentExpression(node, meta) {
   const condition = mapExistentialExpression(unsoaked.condition, meta);
   const assignTarget = mapExpression(unsoaked.body, meta);
   const assignValue = mapExpression(node.value, meta);
+  const operator = node.context || '=';
 
   return b.conditionalExpression(
     condition,
-    b.assignmentExpression('=', assignTarget, assignValue),
+    b.assignmentExpression(operator, assignTarget, assignValue),
     b.unaryExpression('void', b.literal(0))
   );
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -224,8 +224,7 @@ function mapCall(node, meta) {
   const {superMethodName} = meta;
 
   // fallback early if variable name contains an existential operator
-  if (node.variable && (findIndex(get(node, 'variable.base.properties'), {soak: true}) > -1 ||
-     (node.variable.properties && findIndex(node.variable.properties, {soak: true}) > -1))) {
+  if (isSoaked(node)) {
     return fallback(node, meta);
   }
 
@@ -599,6 +598,13 @@ function mapTryCatchBlock(node, meta) {
 
 function mapReturnStatement(node, meta) {
   return b.returnStatement(node.expression ? mapExpression(node.expression, meta) : null);
+}
+
+function isSoaked(node) {
+  return (
+    (node.variable && findIndex(get(node, 'variable.base.properties'), {soak: true}) > -1) ||
+    (node.variable && node.variable.properties && findIndex(node.variable.properties, {soak: true}) > -1)
+  );
 }
 
 function mapStatement(node, meta) {
@@ -1581,7 +1587,24 @@ function mapParamToAssignment(node) {
   return assignment;
 }
 
+function mapExistentialAssignmentExpression(node, meta) {
+  const unsoaked = node.variable.unfoldSoak(meta);
+  const condition = mapExistentialExpression(unsoaked.condition, meta);
+  const assignTarget = mapExpression(unsoaked.body, meta);
+  const assignValue = mapExpression(node.value, meta);
+
+  return b.conditionalExpression(
+    condition,
+    b.assignmentExpression('=', assignTarget, assignValue),
+    b.unaryExpression('void', b.literal(0))
+  );
+}
+
 function mapAssignmentExpression(node, meta) {
+  if (isSoaked(node)) {
+    return mapExistentialAssignmentExpression(node, meta);
+  }
+
   let variable;
   const props = get(node, 'variable.base.properties') || [];
   if (any(props, {this: true})) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,6 +18,11 @@ const IS_NUMBER = /^[+-]?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)$/i;
 const IS_STRING = /^['"]/;
 const IS_REGEX = /^\//;
 
+function isThisMemberExpression(node) {
+  return node.type === 'MemberExpression' &&
+      (node.object.type === 'ThisExpression' || node.object.name === 'this');
+}
+
 function mapBoolean(node) {
   if (node.base.val === 'true') {
     return b.literal(true);
@@ -816,20 +821,32 @@ function mapInArrayExpression(node, meta) {
 }
 
 function extractAssignStatementsByArguments(nodes) {
-  return nodes
-    .map(node => node.type === 'AssignmentExpression' ? node.left : node)
-    .map(node => node.type === 'RestElement' ? node.argument : node)
-    .filter(node => node.type === 'MemberExpression' &&
-        (node.object.type === 'ThisExpression' || node.object.name === 'this'))
-    .map(node =>
-      b.expressionStatement(
-        b.assignmentExpression(
-          '=',
-          node,
-          node.property
-        )
-      )
+  function mapPatternThisAssignmentsToMemberExpressions(node) {
+    return node.properties.filter(
+      assignment => assignment.value.name === 'this'
+    ).map(assignment =>
+      b.memberExpression(b.thisExpression(), b.identifier(assignment.key.name))
     );
+  }
+
+  return flatten(
+    nodes
+      .map(node => node.type === 'AssignmentExpression' ? node.left : node)
+      .map(node => node.type === 'RestElement' ? node.argument : node)
+      .map(node => node.type === 'ObjectPattern' ?
+        mapPatternThisAssignmentsToMemberExpressions(node) : node
+      )
+  )
+  .filter(isThisMemberExpression)
+  .map(node =>
+    b.expressionStatement(
+      b.assignmentExpression(
+        '=',
+        node,
+        node.property
+      )
+    )
+  );
 }
 
 function normalizeArgument(node) {
@@ -841,8 +858,7 @@ function normalizeArgument(node) {
       node.right
     );
   }
-  if (node.type === 'MemberExpression' &&
-     (node.object.type === 'ThisExpression' || node.object.name === 'this')) {
+  if (isThisMemberExpression(node)) {
     return {type: 'Identifier', name: node.property.name};
   }
   return node;

--- a/src/parser.js
+++ b/src/parser.js
@@ -217,7 +217,7 @@ function mapArguments(args, meta) {
     if (type === 'Arr') {
       return mapArrayPattern(arg.name, meta);
     } else if (type === 'Obj') {
-      return mapObjectPattern(arg.name.properties, meta, true);
+      return mapObjectPattern(arg.name.properties, meta);
     }
 
     return mapExpression(arg, meta);
@@ -1038,21 +1038,6 @@ function mapFunction(node, meta) {
     setupStatements = tailStatements.concat(setupStatements);
   }
 
-  if (meta.scope.paramThisDestructures) {
-    setupStatements = meta.scope.paramThisDestructures.map(paramThisDestructure => (
-      b.expressionStatement(
-        b.assignmentExpression(
-          '=',
-          b.memberExpression(
-            b.thisExpression(),
-            paramThisDestructure
-          ),
-          paramThisDestructure
-        )
-      )
-    ));
-  }
-
   // since we are going to be using an arrow function, we can throw away the special
   // context that CoffeeScript created for us
   meta.scope.method.context = 'this';
@@ -1667,20 +1652,14 @@ function mapObjectPatternItem(node, meta) {
   throwError(node.locationData, `can't convert node of type: ${type} to ObjectPatternItem - not recognized`);
 }
 
-function mapObjectPattern(nodes, meta, extractThis = false) {
+function mapObjectPattern(nodes, meta) {
   return b.objectPattern(nodes.map(node => {
     const {operatorToken} = node;
     let prop;
-    const key = mapKey(node.variable || node, meta);
-
-    if (extractThis && node.properties && node.properties.length) {
-      meta.scope.paramThisDestructures = meta.scope.paramThisDestructures || [];
-      meta.scope.paramThisDestructures.push(key);
-    }
 
     prop = b.property(
       'init',
-      key,
+      mapKey(node.variable || node, meta),
       mapObjectPatternItem(node, meta)
     );
 

--- a/test/test.js
+++ b/test/test.js
@@ -928,6 +928,14 @@ describe('existential assignment', () => {
 };`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('handles increment-assign', () => {
+    const example = `foo.bar?.car += qux`
+    const expected =
+`var ref;
+((ref = foo.bar) != null ? ref.car += qux : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('FunctionExpression', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -897,23 +897,28 @@ class A extends B {
 describe('existential assignment', () => {
   it('handles soaked variable', () => {
     const example = `foo?.bar = "buzz" || ""`;
-    const expected = `(foo != null ? foo.bar = "buzz" || "" : void 0);`;
+    const expected =
+`if (foo != null) {
+  foo.bar = "buzz" || "";
+}`;
     expect(compile(example)).toEqual(expected);
   });
 
   it('handles soaked variable property', () => {
     const example = `foo.bar?.car = "qux"`;
     const expected =
-`var ref;
-((ref = foo.bar) != null ? ref.car = "qux" : void 0);`;
+`if (foo.bar != null) {
+  foo.bar.car = "qux";
+}`;
     expect(compile(example)).toEqual(expected);
   });
 
   it('handles soaked method call', () => {
     const example = `foo.bar()?.car = "qux"`;
     const expected =
-`var ref;
-((ref = foo.bar()) != null ? ref.car = "qux" : void 0);`;
+`if (foo.bar() != null) {
+  foo.bar().car = "qux";
+}`;
     expect(compile(example)).toEqual(expected);
   });
 
@@ -924,16 +929,19 @@ describe('existential assignment', () => {
 
     const expected =
 `var bam = function() {
-  return (foo != null ? foo.bar = "buzz" : void 0);
+  if (foo != null) {
+    return foo.bar = "buzz";
+  }
 };`;
     expect(compile(example)).toEqual(expected);
   });
 
   it('handles increment-assign', () => {
-    const example = `foo.bar?.car += qux`
+    const example = `foo.bar?.car += qux`;
     const expected =
-`var ref;
-((ref = foo.bar) != null ? ref.car += qux : void 0);`;
+`if (foo.bar != null) {
+  foo.bar.car += qux;
+}`;
     expect(compile(example)).toEqual(expected);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1006,6 +1006,24 @@ describe('FunctionExpression', () => {
     expect(compile(example)).toEqual(expected);
   });
 
+  it('({@a, @b, c}, @d) => c', () => {
+    const example = '({@a, @b, c}, @d) => @a + c';
+    const expected =
+`(
+  {
+    a,
+    b,
+    c
+  },
+  d) => {
+  this.a = a;
+  this.b = b;
+  this.d = d;
+  return this.a + c;
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
+
   it('turns empty object or array parameter into normal parameter, prevents naming collisions', () => {
     const example = 'fn = ({}, bo, [], ba) ->';
     const expected = `var fn = function(arg, bo, arg1, ba) {};`;

--- a/test/test.js
+++ b/test/test.js
@@ -894,6 +894,42 @@ class A extends B {
   });
 });
 
+describe('existential assignment', () => {
+  it('handles soaked variable', () => {
+    const example = `foo?.bar = "buzz" || ""`;
+    const expected = `(foo != null ? foo.bar = "buzz" || "" : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles soaked variable property', () => {
+    const example = `foo.bar?.car = "qux"`;
+    const expected =
+`var ref;
+((ref = foo.bar) != null ? ref.car = "qux" : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles soaked method call', () => {
+    const example = `foo.bar()?.car = "qux"`;
+    const expected =
+`var ref;
+((ref = foo.bar()) != null ? ref.car = "qux" : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles return-assignments', () => {
+    const example =
+`bam = ->
+  foo?.bar = "buzz"`;
+
+    const expected =
+`var bam = function() {
+  return (foo != null ? foo.bar = "buzz" : void 0);
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
+});
+
 describe('FunctionExpression', () => {
   it('fn = (a,b) -> console.log a, b', () => {
     const example = `fn = (a,b) -> console.log a, b`;

--- a/test/test.js
+++ b/test/test.js
@@ -2377,22 +2377,6 @@ describe('destructuring arguments', () => {
     expect(compile(example)).toEqual(expected);
   });
 
-  it('({@a, @b, c}) => c', () => {
-    const example = '({@a, @b, c}) => @a + c';
-    const expected =
-`(
-  {
-    a,
-    b,
-    c
-  }) => {
-  this.a = a;
-  this.b = b;
-  return this.a + c;
-};`;
-    expect(compile(example)).toEqual(expected);
-  });
-
   it('([a, b, c]) => a', () => {
     const example = `([a, b, c]) => a + b + c`;
     const expected =


### PR DESCRIPTION
This builds on the `hoist_private_class_vars` PR.  Private/static calls within a class are now moved outside/below the class definition.

Sample conversions:

**`tax_code_column.coffee`** (the original intent of this mixin seems wonky, but it still translates)

``` coffeescript
class Shopify.TaxCodeColumn extends Shopify.AutocompleteV2.SingleSelectRemoteSourceAutocomplete
  Shopify.Mixin(@prototype, Shopify.SpreadsheetColumn::)
  # SNIP class code.
```

``` js
Shopify.TaxCodeColumn = class TaxCodeColumn extends Shopify.AutocompleteV2.SingleSelectRemoteSourceAutocomplete {
  // SNIP class code.
};

Shopify.Mixin(TaxCodeColumn.prototype, Shopify.SpreadsheetColumn.prototype);
```

---

**`theme_editor/data/block.coffee`**

``` coffeescript
class ThemeEditor.Block
  _.extend(@prototype, EventMixin)
  # SNIP class code.
```

``` js
ThemeEditor.Block = class Block {
  // SNIP class code.
}
_.extend(Block.prototype, EventMixin);
```

---

**`theme_editor/pickers/color_picker.coffee`**

``` coffeescript
class ThemeEditor.Pickers.Color extends ThemeEditor.Picker
  @claimSettingType('color')
  # SNIP class code.
```

``` js
ThemeEditor.Pickers.Color = class Color extends ThemeEditor.Picker {
  // SNIP class code.
}

Color.claimSettingType("color");
```

/cc @lemonmade, @fandy, @justinthec 
