### PR TITLE
Simple class names shouldn't break private class call movement

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -643,9 +643,13 @@ function mapStatement(node, meta) {
   return b.expressionStatement(mapExpression(node, meta));
 }
 
-function getClassName(classNode) {
-  const nameProperties = classNode.variable.properties;
-  return nameProperties[nameProperties.length - 1].name.value;
+function getClassName({variable}) {
+  const nameProperties = variable.properties;
+  if (nameProperties.length > 0) {
+    return nameProperties[nameProperties.length - 1].name.value;
+  }
+
+  return variable.base.value;
 }
 
 function mapClassPrivateVariables(classNode, meta) {

--- a/test/test.js
+++ b/test/test.js
@@ -174,13 +174,13 @@ D();`
 
   it('moves static class method calls to after the class definition', () => {
     const example = `
-class A.B.C
+class A
   @foo("bar")
 `;
 
     expect(compile(example)).toEqual(
-`A.B.C = class C {};
-C.foo("bar");`
+`class A {}
+A.foo("bar");`
     );
   });
 


### PR DESCRIPTION
Previous logic assumed that we'd always have nested class names.  `core` unit tests have some non-nested class names.

/cc @lemonmade, @justinthec 
