### PR TITLE
Translate `{@foo}` to `{foo: this.foo}`

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -89,12 +89,26 @@ function mapKey(node) {
 }
 
 function mapObjectExpression(node, meta) {
-  return b.objectExpression(node.base.properties.map(property =>
-    b.property(
+  return b.objectExpression(node.base.properties.map(property => {
+    let keyExpression;
+    let valueExpression;
+    if (nodeHasProperties(property)) {
+      keyExpression = mapExpression(property.properties[0], meta);
+      valueExpression = mapMemberExpression(property, meta);
+    } else {
+      keyExpression = mapExpression(property.variable || property.base, meta);
+      valueExpression = mapExpression(property.value || property.base, meta);
+    }
+
+    const result = b.property(
       'init',
-      mapExpression(property.variable || property.base, meta),
-      mapExpression(property.value || property.base, meta))
-  ));
+      keyExpression,
+      valueExpression
+    );
+
+    //result.shorthand = (keyExpression.name === valueExpression.name);
+    return result;
+  }));
 }
 
 function mapArrayExpression(node, meta) {

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,25 @@ describe('Values', () => {
     expect(compile('false')).toEqual('false;');
   });
 
+  it('object shorthand', () => {
+    const example = `
+class A
+  foo: ->
+    bar({@baz, qux})
+`;
+
+    expect(compile(example)).toEqual(
+`class A {
+  foo() {
+    return bar({
+      baz: this.baz,
+      qux
+    });
+  }
+}`
+    );
+  });
+
   it('undefined', () => {
     expect(compile('undefined')).toEqual('undefined;');
   });


### PR DESCRIPTION
Previously, `{@foo}` would be translated to `{this: this}` 😬 

For nodes with sub-properties, this tweaks the `mapObjectExpression` logic to:
* Use the end of the property chain as a key
  * Even CoffeeScript doesn't allow nested chains, so element `0` is always last
* Use `mapMemberExpression` to generate a fully-qualified value

Please review: @lemonmade, @TylerHorth