### PR TITLE
Add variable to catch blocks

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -13,6 +13,8 @@ import isArray from 'lodash/lang/isArray';
 import any from 'lodash/collection/any';
 import jsc from 'jscodeshift';
 
+const DEFAULT_CATCH_VARIABLE_NAME = 'err';
+
 // regexes taken from coffeescript parser
 const IS_NUMBER = /^[+-]?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)$/i;
 const IS_STRING = /^['"]/;
@@ -578,7 +580,9 @@ function mapTryCatchBlock(node, meta) {
   let catchBlock = null;
   if (node.recovery) {
     const recovery = mapBlockStatement(node.recovery, meta);
-    const errorVar = mapLiteral({base: node.errorVariable}, meta);
+    const errorVar = node.errorVariable ?
+      mapLiteral({base: node.errorVariable}, meta) :
+      b.identifier(DEFAULT_CATCH_VARIABLE_NAME);
 
     catchBlock = b.catchClause(
       errorVar,

--- a/src/parser.js
+++ b/src/parser.js
@@ -582,7 +582,7 @@ function mapTryCatchBlock(node, meta) {
     const recovery = mapBlockStatement(node.recovery, meta);
     const errorVar = node.errorVariable ?
       mapLiteral({base: node.errorVariable}, meta) :
-      b.identifier(DEFAULT_CATCH_VARIABLE_NAME);
+      b.identifier(meta.scope.freeVariable(DEFAULT_CATCH_VARIABLE_NAME));
 
     catchBlock = b.catchClause(
       errorVar,

--- a/test/test.js
+++ b/test/test.js
@@ -1971,13 +1971,20 @@ finally
 try
   foo()
 catch
-  return
+  try
+    bar()
+  catch
+    return
 `;
     const expected =
 `try {
   foo();
-} catch (err) {
-  return;
+} catch (err1) {
+  try {
+    bar();
+  } catch (err) {
+    return;
+  }
 }`;
     expect(compile(example)).toEqual(expected);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1966,6 +1966,22 @@ finally
     expect(compile(example)).toEqual(expected);
   });
 
+  it('inserts missing catch var', () => {
+    const example = `
+try
+  foo()
+catch
+  return
+`;
+    const expected =
+`try {
+  foo();
+} catch (err) {
+  return;
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
   it('maps try expressions', () => {
     const example = `x = try y()`;
     const expected =


### PR DESCRIPTION
JS requires a variable for `catch` blocks, CoffeeScript allows it to be omitted.  This PR adds a fallback variable (`err`) to JS.

Please review: @lemonmade, @TylerHorth 