### PR TITLE
Only identifiers/literal should be candidates for shorthand properties

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -88,6 +88,17 @@ function mapKey(node) {
   }
 }
 
+function isKeyValueMatch(key, value) {
+  if (!n.Identifier.check(value)) {
+    return false;
+  }
+
+  return (
+    (n.Literal.check(key) && key.value === value.name) ||
+    (n.Identifier.check(key) && key.name === value.name)
+  );
+}
+
 function mapObjectExpression(node, meta) {
   return b.objectExpression(node.base.properties.map(property => {
     let keyExpression;
@@ -98,6 +109,10 @@ function mapObjectExpression(node, meta) {
     } else {
       keyExpression = mapExpression(property.variable || property.base, meta);
       valueExpression = mapExpression(property.value || property.base, meta);
+
+      if (isKeyValueMatch(keyExpression, valueExpression)) {
+        keyExpression = valueExpression;
+      }
     }
 
     const result = b.property(
@@ -105,8 +120,7 @@ function mapObjectExpression(node, meta) {
       keyExpression,
       valueExpression
     );
-
-    result.shorthand = (keyExpression.name === valueExpression.name);
+    result.shorthand = (keyExpression === valueExpression);
     return result;
   }));
 }

--- a/test/test.js
+++ b/test/test.js
@@ -56,7 +56,15 @@ describe('Values', () => {
     const example = `
 class A
   foo: ->
-    bar({@baz, qux})
+    bar({
+      @baz,
+      qux,
+      "foobar": foobar,
+      bar: qux,
+      baz: "baz",
+      qux: (1 + 2),
+      "foo": {}
+    })
 `;
 
     expect(compile(example)).toEqual(
@@ -64,7 +72,12 @@ class A
   foo() {
     return bar({
       baz: this.baz,
-      qux
+      qux,
+      foobar,
+      bar: qux,
+      baz: "baz",
+      qux: (1 + 2),
+      "foo": {}
     });
   }
 }`


### PR DESCRIPTION
My fix for #14 added some shorthand property logic.  Unfortunately, it's a little too eager.  If two AST type without a `name` property were compared, then `undefined === undefined`, and they were flagged as shorthand :/

This PR makes the key/value check stricter by comparing only identifiers/literals.

Please review @lemonmade, @TylerHorth 