### PR TITLE
Hoist inner classes to before their outer class definition

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -670,6 +670,12 @@ function mapClassPrivateVariables(classNode, meta) {
   );
 }
 
+function mapInnerClasses(classNode, meta) {
+  return classNode.body.expressions
+    .filter(classExpression => classExpression.constructor.name === 'Class')
+    .map(innerClass => mapClassDeclaration(innerClass, meta));
+}
+
 function mapClassPrivateCalls(classNode, meta) {
   const privateCalls = classNode.body.expressions
     .filter(classExpression => classExpression.constructor.name === 'Call')
@@ -700,10 +706,13 @@ function mapBlockStatements(node, meta) {
     const type = expr.constructor.name;
     const privateVars = [];
     const privateCalls = [];
+    const innerClasses = [];
+
     let prototypeProps = [];
     if (type === 'Class') {
       privateVars.push(...mapClassPrivateVariables(expr, meta));
       privateCalls.push(...mapClassPrivateCalls(expr, meta));
+      innerClasses.push(...mapInnerClasses(expr, meta));
 
       // extract prototype assignments
       prototypeProps = flatten(expr.body.expressions
@@ -731,6 +740,7 @@ function mapBlockStatements(node, meta) {
     }
 
     return privateVars
+      .concat(innerClasses)
       .concat([mapStatement(expr, meta)])
       .concat(privateCalls)
       .concat(prototypeProps);

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,27 @@ describe('throw statements', () => {
   });
 });
 
+describe('inner classes', () => {
+  it('should be declared before outer class', () => {
+    const example = `
+class Foo
+  @foo: 1;
+
+  class Bar
+    @bar: 2
+`;
+    const expected =
+`class Bar {
+  static bar = 2;
+}
+
+class Foo {
+  static foo = 1;
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+});
+
 describe('private class statements', () => {
   it('prevents private calls in anonymous classes', () => {
     const example =


### PR DESCRIPTION
Inner classes were being omitted from `decaf`'s output.  This PR takes inner classes, and inserts them before their parent class.  

(Note that this doesn't account for anything like inner classes that reference their parent class, but that's acceptable because Shopify doesn't have any of those.)

Please review @lemonmade, @TylerHorth 