### PR TITLE
Guard against null identifiers when generating for loops with `Object.keys`/`Object.values`

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1344,7 +1344,11 @@ function mapForGuard(guardNode, meta) {
 }
 
 function guardLoopSource(source) {
-  if (!n.Identifier.check(source) && !n.MemberExpression.check(source)) {
+  if (
+    !n.Identifier.check(source) &&
+    !n.MemberExpression.check(source) &&
+    !n.CallExpression.check(source)
+  ) {
     return source;
   }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1343,6 +1343,14 @@ function mapForGuard(guardNode, meta) {
   return guardClause;
 }
 
+function guardLoopSource(source) {
+  if (!n.Identifier.check(source) && !n.MemberExpression.check(source)) {
+    return source;
+  }
+
+  return b.logicalExpression('||', source, b.objectExpression([]));
+}
+
 function mapForStatement(node, meta) {
   let blockStatement = mapBlockStatement(node.body, meta);
 
@@ -1410,7 +1418,7 @@ function mapForStatement(node, meta) {
           b.identifier('Object'),
           b.identifier(method)
         ),
-        [mapExpression(node.source, meta)]
+        [guardLoopSource(mapExpression(node.source, meta))]
       ),
       blockStatement
     );
@@ -1495,7 +1503,7 @@ function mapForExpression(node, meta) {
     }
     target = b.callExpression(
       b.memberExpression(b.identifier('Object'), b.identifier(method)),
-      [leftHand]
+      [guardLoopSource(leftHand)]
     );
   } else {
     target = leftHand;

--- a/test/test.js
+++ b/test/test.js
@@ -2239,6 +2239,17 @@ say key, value for key, value of foo`;
     expect(compile(example)).toEqual(expected);
   });
 
+  it('adds default entries value for key, value of baz.qux()', () => {
+    const example =
+`for foo, bar of baz.qux()
+  foo(bar)
+`;
+    const expected =
+`for (var [foo, bar] of Object.entries(baz.qux() || {})) {
+  foo(bar);
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
 
   it('say key, value for key, value of {a: 1}', () => {
     const example =

--- a/test/test.js
+++ b/test/test.js
@@ -2216,6 +2216,29 @@ describe('comprehensions', () => {
     expect(compile('a(b) for {a, b} in c')).toEqual(expected);
   });
 
+  it('adds default entries value for key, value of foo', () => {
+    const example = `
+say key, value for key, value of foo`;
+
+    const expected =
+`for (var [key, value] of Object.entries(foo || {})) {
+  say(key, value);
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('adds default entries value for key, value of baz.qux', () => {
+    const example =
+`for foo, bar of baz.qux
+  foo(bar)
+`;
+    const expected =
+`for (var [foo, bar] of Object.entries(baz.qux || {})) {
+  foo(bar);
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
 
   it('say key, value for key, value of {a: 1}', () => {
     const example =
@@ -2321,7 +2344,7 @@ describe('comprehensions', () => {
   it('(c(a) for a, c of b).sort()', () => {
     const example = `(c(a) for a, c of b).sort()`;
     const expected =
-`(Object.entries(b).map(([a, c]) => {
+`(Object.entries(b || {}).map(([a, c]) => {
   return c(a);
 })).sort();`;
     expect(compile(example)).toEqual(expected);
@@ -2330,7 +2353,7 @@ describe('comprehensions', () => {
   it('(a for a of b).sort()', () => {
     const example = `(a for a of b).sort()`;
     const expected =
-`(Object.keys(b).map(a => {
+`(Object.keys(b || {}).map(a => {
   return a;
 })).sort();`;
     expect(compile(example)).toEqual(expected);


### PR DESCRIPTION
This adds a fallback object to any `for` loop that relies on `Object.keys`/`Object.values`.

**Rationale:**
CoffeScript translates `foo() for foo, bar of baz` into a `for (foo in baz)` JS loop.  A for/in loop is null safe, so all is well.

`decaf` currently translates `foo() for foo, bar of baz` to `for (var [foo, bar] of Object.entries(baz.qux)`.  `Object.entries` is not null safe, so this change adds ` || {}` to the call parameter (ugly 😬).

Please review @lemonmade, @TylerHorth 